### PR TITLE
Fix capitalisation of some parts of reference title

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,7 +18,7 @@ authors:
     affiliation: Karlsruhe Institute of Technology
     orcid: "https://orcid.org/0000-0002-7498-7640"
 
-title: "Tutorial on Meta-Reinforcement Learning and GP-MPC at the RL4AA'24 Workshop"
+title: "Tutorial on Meta-Reinforcement Learning and {GP-MPC} at the {RL4AA'24} Workshop"
 date-released: 2024-03-27
 url: "https://github.com/RL4AA/rl4aa24-tutorial"
 doi: 10.5281/zenodo.10886639

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please use the following DOI when citing this code:
                     Xu, Chenran and
                     Santamaria Garcia, Andrea
                  },
-  title        = {Tutorial on Meta-Reinforcement Learning and GP-MPC at the RL4AA'24 Workshop},
+  title        = {Tutorial on Meta-Reinforcement Learning and {GP-MPC} at the {RL4AA'24} Workshop},
   month        = {03},
   year         = {2024},
   publisher    = {Zenodo},


### PR DESCRIPTION
I was referencing this and noticed that some things that should always be capitalised aren't.